### PR TITLE
feat: added customization for `tableActions` column label and JQ interpolation logic for `openDrawer` and `openModal` titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Previous changes not listed in this document can be traced using Git history.
 
+## [1.0.22] - 2026-04-27
+
+### Added
+- Added customization for `tableActions` column label
+- Added JQ interpolation logic for `openDrawer` and `openModal` titles
+
 ## [1.0.21] - 2026-04-23
 
 ### Fixed

--- a/docs/widgets-api-reference.md
+++ b/docs/widgets-api-reference.md
@@ -687,6 +687,8 @@ Table displays structured data with customizable columns and pagination
 | tableActions[].button.size | no | the size of the button | `small` \| `middle` \| `large` |
 | tableActions[].button.type | no | the visual style of the button | `default` \| `text` \| `link` \| `primary` \| `dashed` |
 | tableActions[].clickActionId | no | the id of the action to be executed when the button is clicked | string |
+| tableActionsColumn | no | customization for the table actions column | object |
+| tableActionsColumn.label | no | table actions column customized label, default is empty string | string |
 
 
 [Examples](../src/examples/widgets/Table/Table.example.yaml)

--- a/src/examples/widgets/Button/Button.example.yaml
+++ b/src/examples/widgets/Button/Button.example.yaml
@@ -450,7 +450,6 @@ spec:
   widgetData:
     label: Open Modal Default
     type: primary
-    
     size: middle
     clickActionId: open-modal-default
     actions:
@@ -458,7 +457,7 @@ spec:
         - id: open-modal-default
           type: openModal
           resourceRefId: example-yamlviewer-simple-json
-          title: Default Modal Example
+          title: ${"Default Modal Example:" + " " + .widget.status.widgetData.label}
           loading:
             display: true
           size: default

--- a/src/examples/widgets/Table/Table.example.yaml
+++ b/src/examples/widgets/Table/Table.example.yaml
@@ -657,6 +657,8 @@ spec:
         button:
           label: Navigate
           type: default
+    tableActionsColumn:
+      label: Actions
   resourcesRefs:
     items: []
   resourcesRefsTemplate:

--- a/src/hooks/useHandleActions.ts
+++ b/src/hooks/useHandleActions.ts
@@ -200,16 +200,30 @@ export const useHandleAction = () => {
         case 'openDrawer': {
           const { size, title } = action
 
+          let drawerTitle: string | undefined
+          if (title) {
+            drawerTitle = title.startsWith('${')
+              ? await resolveJq(title, { json: customPayload, widget })
+              : title
+          }
+
           setIsActionLoading(false)
-          openDrawer({ size, title, widgetEndpoint: path })
+          openDrawer({ size, title: drawerTitle, widgetEndpoint: path })
 
           break
         }
         case 'openModal': {
           const { customWidth, size, title } = action
 
+          let modalTitle: string | undefined
+          if (title) {
+            modalTitle = title.startsWith('${')
+              ? await resolveJq(title, { json: customPayload, widget })
+              : title
+          }
+
           setIsActionLoading(false)
-          openModal({ customWidth, size, title, widgetEndpoint: path })
+          openModal({ customWidth, size, title: modalTitle, widgetEndpoint: path })
 
           break
         }

--- a/src/widgets/Table/Table.schema.json
+++ b/src/widgets/Table/Table.schema.json
@@ -466,6 +466,17 @@
                 },
                 "additionalProperties": false
               }
+            },
+            "tableActionsColumn": {
+              "description": "customization for the table actions column",
+              "type": "object",
+              "properties": {
+                "label": {
+                  "description": "table actions column customized label, default is empty string",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/src/widgets/Table/Table.tsx
+++ b/src/widgets/Table/Table.tsx
@@ -21,7 +21,7 @@ export type NormalizedRow = {
 } & Record<string, unknown>
 
 const Table = ({ resourcesRefs, uid, widgetData }: WidgetProps<TableWidgetData>) => {
-  const { actions, columns, data, pageSize, prefix, tableActions } = widgetData
+  const { actions, columns, data, pageSize, prefix, tableActions, tableActionsColumn } = widgetData
   const { getFilteredData } = useFilter()
 
   // TODO: check if this works with RESTAction, it should not be displayed
@@ -152,7 +152,7 @@ const Table = ({ resourcesRefs, uid, widgetData }: WidgetProps<TableWidgetData>)
             />))
           }
         </div>,
-      title: 'Actions',
+      title: tableActionsColumn?.label ?? '',
     }]
     : []
 

--- a/src/widgets/Table/Table.type.d.ts
+++ b/src/widgets/Table/Table.type.d.ts
@@ -319,6 +319,15 @@ export interface Table {
          */
         clickActionId?: string
       }[]
+      /**
+       * customization for the table actions column
+       */
+      tableActionsColumn?: {
+        /**
+         * table actions column customized label, default is empty string
+         */
+        label?: string
+      }
     }
     resourcesRefs?: {
       items: {


### PR DESCRIPTION
This PR has the goal of:
- adding customization for `tableActions` column label
- adding JQ interpolation logic for `openDrawer` and `openModal` titles