### PR TITLE
fix: fixed crash in `Notifications` when reaching end of event list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Previous changes not listed in this document can be traced using Git history.
 
+## [1.0.23] - 2026-04-28
+
+### Fixed
+- Fixed crash in `Notifications` when reaching end of event list
+
 ## [1.0.22] - 2026-04-27
 
 ### Added

--- a/src/hooks/useGetEvents.ts
+++ b/src/hooks/useGetEvents.ts
@@ -160,8 +160,16 @@ export function useGetEvents({
 
     const merged = [...sseEvents, ...fetchedEvents]
     const seen = new Set<string>()
+
     return merged.filter((item) => {
-      if (seen.has(item.global_uid)) { return false }
+      if (!item || !item.global_uid) {
+        return false
+      }
+
+      if (seen.has(item.global_uid)) {
+        return false
+      }
+
       seen.add(item.global_uid)
       return true
     })


### PR DESCRIPTION
This PR has the goal of fixing a bug in the `Notifications` component to make sure the app does not crash when reaching the end of the events list.