### PR TITLE
refactor: updated `Notifications` error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Previous changes not listed in this document can be traced using Git history.
 
+## [1.0.25] - 2026-05-12
+
+### Changed
+- Updated error handling for `Notifications` displaying
+
 ## [1.0.24] - 2026-05-11
 
 ### Changed

--- a/src/components/WidgetRenderer/WidgetRenderer.tsx
+++ b/src/components/WidgetRenderer/WidgetRenderer.tsx
@@ -250,6 +250,10 @@ const WidgetRenderer = ({
         )
       }
 
+      if (code === 403 && message?.includes('notifications')) {
+        return null
+      }
+
       if (code === 404 && wasEverLoaded) {
         return null
       }


### PR DESCRIPTION
This PR has the goal of adding a specific handling for the displaying of the `Notifications` widget: in case it's forbidden for a specific user role to see it, the widget will not be displayed (instead of showing an error message).