### PR TITLE
feat: persist active tab in TabList via URL search param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Previous changes not listed in this document can be traced using Git history.
 
 ### Added
 
+- Added persistence of active tab in `TabList`
 - Added `externalNavigate` and `refresh` actions
 
 ## [1.0.26] - 2026-06-16

--- a/src/widgets/TabList/TabList.tsx
+++ b/src/widgets/TabList/TabList.tsx
@@ -1,6 +1,7 @@
 import type { TabsProps } from 'antd'
 import { Empty, Result, Tabs } from 'antd'
 import { useMemo } from 'react'
+import { useSearchParams } from 'react-router'
 
 import WidgetRenderer from '../../components/WidgetRenderer'
 import type { WidgetProps } from '../../types/Widget'
@@ -13,6 +14,7 @@ export type TabListWidgetData = WidgetType['spec']['widgetData']
 
 const TabList = ({ resourcesRefs, uid, widgetData }: WidgetProps<TabListWidgetData>) => {
   const { items } = widgetData
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const tabItems = useMemo(() => {
     return items.reduce<NonNullable<TabsProps['items']>>((acc, { label, resourceRefId, title }, index) => {
@@ -40,11 +42,25 @@ const TabList = ({ resourcesRefs, uid, widgetData }: WidgetProps<TabListWidgetDa
     }, [])
   }, [items, resourcesRefs, uid])
 
+  const paramKey = `tab-${uid}`
+  const storedKey = searchParams.get(paramKey)
+  const activeKey = tabItems.some(({ key }) => key === storedKey) ? storedKey! : (tabItems[0]?.key ?? '')
+
+  const handleTabChange = (key: string) => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      next.set(paramKey, key)
+      return next
+    },
+    { replace: true }
+    )
+  }
+
   if (!items.length) {
     return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
   }
 
-  return <Tabs items={tabItems} key={uid} />
+  return <Tabs activeKey={activeKey} items={tabItems} key={uid} onChange={handleTabChange} />
 }
 
 export default TabList


### PR DESCRIPTION
## Summary

- `TabList` now persists the active tab in the URL as a search parameter (`tab-<uid>`)
- The active tab survives page refresh and is shareable via URL
- Tab switches use `replace` (not `push`) to avoid polluting browser history
- Existing search params (including `widgetEndpoint`) are preserved when a tab changes

## Implementation

The change is contained entirely in `src/widgets/TabList/TabList.tsx`:

- `useSearchParams` reads and writes the active tab key
- The param is namespaced per widget instance (`tab-<uid>`) so multiple TabLists on the same page don't collide
- Before applying the stored key, it is validated against the current tab items — if the tab no longer exists (e.g. YAML was updated), it silently falls back to tab 0

## Behaviour across navigation scenarios

| Scenario | What happens |
|---|---|
| User selects tab 2, then refreshes the page | URL is preserved → lands on tab 2 ✓ |
| User selects tab 2, copies and shares the URL | Recipient lands on tab 2 ✓ |
| User clicks the browser back button after switching tabs | Goes to the previous page, not the previous tab (because tab switches use `replace`) ✓ |
| Panel click → `path` navigate to a page containing a TabList | Clean URL, TabList starts at tab 0 (fresh navigation, no prior tab context) ✓ |
| Panel click → `resourceRefId` navigate on the same page | URL becomes `?widgetEndpoint=<encoded>` — tab param stripped, but TabList is not rendered in this state ✓ |
| User navigates away via a nav menu item and comes back via the same item | Fresh URL, tab 0 (expected reset on intentional navigation) ✓ |
| Multiple TabLists on the same page | Each uses its own `tab-<uid>` param — no collisions ✓ |
| YAML updated and the previously active tab no longer exists | Falls back silently to tab 0 ✓ |

## Test plan

- [ ] Open a page with a TabList, switch to a non-default tab, refresh — confirm landing on the same tab
- [ ] Open the URL in a second browser tab — confirm both show the same active tab
- [ ] Switch tabs several times, press browser back — confirm going to the previous page, not cycling through tab history
- [ ] Verify that pages with two or more TabLists persist each independently
- [ ] Trigger a `navigate` action from a widget on the same page — confirm tab param does not interfere

🤖 Generated with [Claude Code](https://claude.com/claude-code)