### PR TITLE
fix: remove enum constraint on event_type in EventList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Previous changes not listed in this document can be traced using Git history.
 - Added persistence of active tab in `TabList`
 - Added `externalNavigate` and `refresh` actions
 
+### Fixed
+
+- Removed `enum` constraint on `event_type` in `EventList` to allow non-standard Kubernetes event types (e.g. `Error`)
+
 ## [1.0.26] - 2026-06-16
 
 ### Added

--- a/src/examples/widgets/EventList/EventList.example.yaml
+++ b/src/examples/widgets/EventList/EventList.example.yaml
@@ -89,6 +89,48 @@ spec:
         - resource_name
         type: string
 ---
+# Mixed event types including non-standard type
+# Expected behavior: Displays three events with different event_type values — Normal (blue), Warning (orange), and Error (grey).
+# Verifies that unknown event types do not cause errors and fall back to the default grey color.
+kind: EventList
+apiVersion: widgets.templates.krateo.io/v1beta1
+metadata:
+  name: example-eventlist-mixed-types
+  namespace: krateo-system
+spec:
+  widgetData:
+    events:
+      - global_uid: "mock-cluster-1:event-normal"
+        cluster_name: "mock-cluster-1"
+        namespace: "default"
+        resource_kind: "Pod"
+        resource_name: "nginx-pod"
+        event_type: "Normal"
+        reason: "Started"
+        message: "Started container nginx"
+        created_at: "2024-04-21T08:20:00Z"
+        raw: ""
+      - global_uid: "mock-cluster-1:event-warning"
+        cluster_name: "mock-cluster-1"
+        namespace: "default"
+        resource_kind: "Pod"
+        resource_name: "my-pod"
+        event_type: "Warning"
+        reason: "FailedScheduling"
+        message: "0/1 nodes are available: 1 Insufficient memory."
+        created_at: "2024-04-20T12:34:56Z"
+        raw: ""
+      - global_uid: "mock-cluster-1:event-error"
+        cluster_name: "mock-cluster-1"
+        namespace: "default"
+        resource_kind: "Deployment"
+        resource_name: "my-deployment"
+        event_type: "Error"
+        reason: "BackoffLimitExceeded"
+        message: "Job has reached the specified backoff limit"
+        created_at: "2024-04-22T09:15:00Z"
+        raw: ""
+---
 # Live updates via SSE
 # Expected behavior: The widget connects to the provided SSE endpoint and updates in real time as new events are received.
 # Use this configuration to test streaming behavior from a live backend.

--- a/src/examples/widgets/EventList/EventList.menu.yaml
+++ b/src/examples/widgets/EventList/EventList.menu.yaml
@@ -49,6 +49,7 @@ spec:
       - resourceRefId: example-eventlist-empty-panel
       - resourceRefId: example-eventlist-basic-panel
       - resourceRefId: example-eventlist-with-prefix-panel
+      - resourceRefId: example-eventlist-mixed-types-panel
       - resourceRefId: example-eventlist-sse-panel
   resourcesRefs:
     items:
@@ -57,19 +58,25 @@ spec:
         name: example-eventlist-empty-panel
         namespace: krateo-system
         resource: panels
-        verb: GET  
+        verb: GET
       - id: example-eventlist-basic-panel
         apiVersion: widgets.templates.krateo.io/v1beta1
         name: example-eventlist-basic-panel
         namespace: krateo-system
         resource: panels
-        verb: GET  
+        verb: GET
       - id: example-eventlist-with-prefix-panel
         apiVersion: widgets.templates.krateo.io/v1beta1
         name: example-eventlist-with-prefix-panel
         namespace: krateo-system
         resource: panels
-        verb: GET      
+        verb: GET
+      - id: example-eventlist-mixed-types-panel
+        apiVersion: widgets.templates.krateo.io/v1beta1
+        name: example-eventlist-mixed-types-panel
+        namespace: krateo-system
+        resource: panels
+        verb: GET
       - id: example-eventlist-sse-panel
         apiVersion: widgets.templates.krateo.io/v1beta1
         name: example-eventlist-sse-panel
@@ -147,6 +154,26 @@ spec:
 kind: Panel
 apiVersion: widgets.templates.krateo.io/v1beta1
 metadata:
+  name: example-eventlist-mixed-types-panel
+  namespace: krateo-system
+spec:
+  widgetData:
+    actions: {}
+    title: 'Mixed event types (Normal, Warning, Error)'
+    items:
+      - resourceRefId: example-eventlist-mixed-types
+  resourcesRefs:
+    items:
+      - id: example-eventlist-mixed-types
+        apiVersion: widgets.templates.krateo.io/v1beta1
+        name: example-eventlist-mixed-types
+        namespace: krateo-system
+        resource: eventlists
+        verb: GET
+---
+kind: Panel
+apiVersion: widgets.templates.krateo.io/v1beta1
+metadata:
   name: example-eventlist-sse-panel
   namespace: krateo-system
 spec:
@@ -162,4 +189,4 @@ spec:
         name: example-eventlist-sse
         namespace: krateo-system
         resource: eventlists
-        verb: GET  
+        verb: GET

--- a/src/widgets/Button/Button.type.d.ts
+++ b/src/widgets/Button/Button.type.d.ts
@@ -202,6 +202,62 @@ export interface Button {
            */
           size?: 'default' | 'large' | 'fullscreen' | 'custom'
         }[]
+        /**
+         * actions to navigate to an external URL
+         */
+        externalNavigate?: {
+          /**
+           * unique identifier for the action
+           */
+          id: string
+          /**
+           * type of action to execute
+           */
+          type: 'externalNavigate'
+          /**
+           * the external URL to navigate to; supports JQ expressions using ${ } syntax
+           */
+          url: string
+          /**
+           * specifies where to open the URL (default: _blank)
+           */
+          target?: '_blank' | '_self' | '_parent' | '_top'
+          /**
+           * whether user confirmation is required before navigating
+           */
+          requireConfirmation?: boolean
+          loading?: {
+            display: boolean
+          }
+        }[]
+        /**
+         * actions to invalidate and reload cached data
+         */
+        refresh?: {
+          /**
+           * unique identifier for the action
+           */
+          id: string
+          /**
+           * type of action to execute
+           */
+          type: 'refresh'
+          /**
+           * list of resourcesRefs item IDs whose widget queries should be invalidated; each ID must match an entry in resourcesRefs.items
+           */
+          resourcesRefsIds?: string[]
+          /**
+           * list of widget kind names (e.g. Table, Panel) whose queries should be invalidated; all widgets of those kinds on the page are re-fetched
+           */
+          widgetKinds?: string[]
+          /**
+           * whether user confirmation is required before refreshing
+           */
+          requireConfirmation?: boolean
+          loading?: {
+            display: boolean
+          }
+        }[]
       }
       /**
        * the background color of the button

--- a/src/widgets/EventList/EventList.schema.json
+++ b/src/widgets/EventList/EventList.schema.json
@@ -59,8 +59,7 @@
                   },
                   "event_type": {
                     "type": "string",
-                    "enum": ["Normal", "Warning"],
-                    "description": "type of the event, e.g., normal or warning"
+                    "description": "type of the event, e.g., Normal, Warning, or Error"
                   },
                   "reason": {
                     "type": "string",

--- a/src/widgets/EventList/EventList.tsx
+++ b/src/widgets/EventList/EventList.tsx
@@ -125,6 +125,11 @@ const EventList = ({ uid, widgetData }: WidgetProps<EventListWidgetData>) => {
     return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
   }
 
+  const eventTypeColor: Record<string, string> = {
+    Normal: 'blue',
+    Warning: 'orange',
+  }
+
   return (
     <div className={styles.container} onScroll={handleScroll}>
       {filteredEventList.map(
@@ -139,7 +144,7 @@ const EventList = ({ uid, widgetData }: WidgetProps<EventListWidgetData>) => {
           resource_name: name,
         }) => (
           <RichRow
-            color={type === 'Normal' ? 'blue' : 'orange'}
+            color={eventTypeColor[type] ?? 'grey'}
             icon={'fa-ellipsis-h'}
             key={`${uid}-${rowUid}`}
             primaryText={

--- a/src/widgets/Form/Form.type.d.ts
+++ b/src/widgets/Form/Form.type.d.ts
@@ -205,6 +205,62 @@ export interface Form {
            */
           size?: 'default' | 'large' | 'fullscreen' | 'custom'
         }[]
+        /**
+         * actions to navigate to an external URL
+         */
+        externalNavigate?: {
+          /**
+           * unique identifier for the action
+           */
+          id: string
+          /**
+           * type of action to execute
+           */
+          type: 'externalNavigate'
+          /**
+           * the external URL to navigate to; supports JQ expressions using ${ } syntax
+           */
+          url: string
+          /**
+           * specifies where to open the URL (default: _blank)
+           */
+          target?: '_blank' | '_self' | '_parent' | '_top'
+          /**
+           * whether user confirmation is required before navigating
+           */
+          requireConfirmation?: boolean
+          loading?: {
+            display: boolean
+          }
+        }[]
+        /**
+         * actions to invalidate and reload cached data
+         */
+        refresh?: {
+          /**
+           * unique identifier for the action
+           */
+          id: string
+          /**
+           * type of action to execute
+           */
+          type: 'refresh'
+          /**
+           * list of resourcesRefs item IDs whose widget queries should be invalidated; each ID must match an entry in resourcesRefs.items
+           */
+          resourcesRefsIds?: string[]
+          /**
+           * list of widget kind names (e.g. Table, Panel) whose queries should be invalidated; all widgets of those kinds on the page are re-fetched
+           */
+          widgetKinds?: string[]
+          /**
+           * whether user confirmation is required before refreshing
+           */
+          requireConfirmation?: boolean
+          loading?: {
+            display: boolean
+          }
+        }[]
       }
       /**
        * custom labels and icons for form buttons

--- a/src/widgets/Panel/Panel.type.d.ts
+++ b/src/widgets/Panel/Panel.type.d.ts
@@ -199,6 +199,62 @@ export interface Panel {
            */
           size?: 'default' | 'large' | 'fullscreen' | 'custom'
         }[]
+        /**
+         * actions to navigate to an external URL
+         */
+        externalNavigate?: {
+          /**
+           * unique identifier for the action
+           */
+          id: string
+          /**
+           * type of action to execute
+           */
+          type: 'externalNavigate'
+          /**
+           * the external URL to navigate to; supports JQ expressions using ${ } syntax
+           */
+          url: string
+          /**
+           * specifies where to open the URL (default: _blank)
+           */
+          target?: '_blank' | '_self' | '_parent' | '_top'
+          /**
+           * whether user confirmation is required before navigating
+           */
+          requireConfirmation?: boolean
+          loading?: {
+            display: boolean
+          }
+        }[]
+        /**
+         * actions to invalidate and reload cached data
+         */
+        refresh?: {
+          /**
+           * unique identifier for the action
+           */
+          id: string
+          /**
+           * type of action to execute
+           */
+          type: 'refresh'
+          /**
+           * list of resourcesRefs item IDs whose widget queries should be invalidated; each ID must match an entry in resourcesRefs.items
+           */
+          resourcesRefsIds?: string[]
+          /**
+           * list of widget kind names (e.g. Table, Panel) whose queries should be invalidated; all widgets of those kinds on the page are re-fetched
+           */
+          widgetKinds?: string[]
+          /**
+           * whether user confirmation is required before refreshing
+           */
+          requireConfirmation?: boolean
+          loading?: {
+            display: boolean
+          }
+        }[]
       }
       /**
        * the id of the action to be executed when the panel is clicked

--- a/src/widgets/Table/Table.type.d.ts
+++ b/src/widgets/Table/Table.type.d.ts
@@ -199,6 +199,62 @@ export interface Table {
            */
           size?: 'default' | 'large' | 'fullscreen' | 'custom'
         }[]
+        /**
+         * actions to navigate to an external URL
+         */
+        externalNavigate?: {
+          /**
+           * unique identifier for the action
+           */
+          id: string
+          /**
+           * type of action to execute
+           */
+          type: 'externalNavigate'
+          /**
+           * the external URL to navigate to; supports JQ expressions using ${ } syntax
+           */
+          url: string
+          /**
+           * specifies where to open the URL (default: _blank)
+           */
+          target?: '_blank' | '_self' | '_parent' | '_top'
+          /**
+           * whether user confirmation is required before navigating
+           */
+          requireConfirmation?: boolean
+          loading?: {
+            display: boolean
+          }
+        }[]
+        /**
+         * actions to invalidate and reload cached data
+         */
+        refresh?: {
+          /**
+           * unique identifier for the action
+           */
+          id: string
+          /**
+           * type of action to execute
+           */
+          type: 'refresh'
+          /**
+           * list of resourcesRefs item IDs whose widget queries should be invalidated; each ID must match an entry in resourcesRefs.items
+           */
+          resourcesRefsIds?: string[]
+          /**
+           * list of widget kind names (e.g. Table, Panel) whose queries should be invalidated; all widgets of those kinds on the page are re-fetched
+           */
+          widgetKinds?: string[]
+          /**
+           * whether user confirmation is required before refreshing
+           */
+          requireConfirmation?: boolean
+          loading?: {
+            display: boolean
+          }
+        }[]
       }
       /**
        * the list of resources that are allowed to be children of this widget or referenced by it


### PR DESCRIPTION
Closes #67

## Summary

- Removed `"enum": ["Normal", "Warning"]` from `event_type` in `EventList.schema.json` — Kubernetes does not enforce this constraint and non-standard types (e.g. `Error`) were causing validation errors
- Updated color fallback in `EventList.tsx`: `Normal` → blue, `Warning` → orange, any other type → grey (previously anything non-Normal defaulted to orange)
- Added `example-eventlist-mixed-types` example with all three event types to verify the fix visually
- Regenerated all TypeScript types and CRDs; applied updated CRD and examples to cluster

## Test plan

- [ ] Open the EventList example page and check the new "Mixed event types" panel
- [ ] Verify `Normal` event renders blue, `Warning` renders orange, `Error` renders grey
- [ ] Confirm no schema validation errors when applying an EventList CR with `event_type: Error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)